### PR TITLE
Field pack compatibility update, plus a quick bug fix

### DIFF
--- a/system/expressionengine/third_party/dynamo/mod.dynamo.php
+++ b/system/expressionengine/third_party/dynamo/mod.dynamo.php
@@ -274,7 +274,7 @@ class Dynamo
 		//convert some of POST like arrays -> pipe delimited lists
 		foreach ($_POST as $key => $value)
 		{
-			if (substr($key, 0, 7) === 'search:' && is_array($value))
+			if (is_array($value))
 			{
 				foreach ($value as $_key => $_value)
 				{

--- a/system/expressionengine/third_party/dynamo/mod.dynamo.php
+++ b/system/expressionengine/third_party/dynamo/mod.dynamo.php
@@ -108,7 +108,8 @@ class Dynamo
 						
 						break;
 					case 'pt_switch':
-						
+					case 'fieldpack_switch':
+
 						$field_settings = @unserialize(base64_decode($row->field_settings));
 						
 						if (is_array($field_settings))

--- a/system/expressionengine/third_party/dynamo/mod.dynamo.php
+++ b/system/expressionengine/third_party/dynamo/mod.dynamo.php
@@ -268,7 +268,7 @@ class Dynamo
 		//convert some of POST like arrays -> pipe delimited lists
 		foreach ($_POST as $key => $value)
 		{
-			if (substr($key, 0, 7) !== 'search:' && is_array($value))
+			if (substr($key, 0, 7) === 'search:' && is_array($value))
 			{
 				foreach ($value as $_key => $_value)
 				{

--- a/system/expressionengine/third_party/dynamo/mod.dynamo.php
+++ b/system/expressionengine/third_party/dynamo/mod.dynamo.php
@@ -93,6 +93,11 @@ class Dynamo
 					case 'pt_dropdown':
 					case 'pt_multiselect':
 					case 'pt_pill':
+					case 'fieldpack_checkboxes':
+					case 'fieldpack_radio_buttons':
+					case 'fieldpack_dropdown':
+					case 'fieldpack_multiselect':
+					case 'fieldpack_pill':
 						
 						$field_settings = @unserialize(base64_decode($row->field_settings));
 						


### PR DESCRIPTION
Thanks for an extremely useful addon. I spotted a couple of issues with the current release:
- Field pack compatibility seems to have been broken as a result of P&T changing their field naming scheme.
- The array to pipe-delimited strings feature had an errant `!==` condition which was throwing a spanner in the works.

This should fix both issues. Thanks!
